### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ If you see a playground here that does not work anymore with the current release
 * [Parse Playground](https://github.com/ultrasaurus/ParsePlayground) - Experimenting with Parse.com in Swift.
 * [S3Uploader](https://github.com/djromero/S3UploaderPlayground) - A playground to upload images to AWS S3.
 * [100 AudioKit Playgrounds](http://audiokit.io/playgrounds/) - Audio synthesis and processing with AudioKit.
+* [AIToolbox](https://github.com/KevinCoble/AIToolbox/tree/master/Playgrounds) - A set of playgrounds showing machine learning algorithms, all implemented with pieces of the AIToolbox framework code.
 
 ## Playground Sets
 *Sets of playgrounds about various topics*


### PR DESCRIPTION
I wanted to get the word out about a set of Playgrounds I created that graphically show how to use machine learning algorithms.  Currently I have ones for linear regression, support vector machines, and neural networks.

I put the proposed addition in 'Libraries', as they reference the AIToolbox framework, although all the code needed is in the Source directory of the Playground - so they do not require a framework to be installed.  They would also fit in the 'Algorithms' section.

The link is also to the Playground subdirectory of the AIToolbox repository, rather than the AIToolbox main page

Thanks for your consideration!