### PR TITLE
Remove non-playground project from list

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -226,9 +226,6 @@
 [submodule "playgrounds/rmirabelli/CoreAnimationSwiftPlaygrounds"]
 	path = playgrounds/rmirabelli/CoreAnimationSwiftPlaygrounds
 	url = https://github.com/rmirabelli/CoreAnimationSwiftPlaygrounds
-[submodule "playgrounds/JakeLin/iOSAnimationSample"]
-	path = playgrounds/JakeLin/iOSAnimationSample
-	url = https://github.com/JakeLin/iOSAnimationSample
 [submodule "playgrounds/d-ronnqvist/Additive-Animations-Playground"]
 	path = playgrounds/d-ronnqvist/Additive-Animations-Playground
 	url = https://github.com/d-ronnqvist/Additive-Animations-Playground

--- a/README.md
+++ b/README.md
@@ -182,7 +182,6 @@ Apple's playgrounds distributed as zip archives have to be downloaded manually.
 * [Core Animation Swift Playgrounds](https://github.com/rmirabelli/CoreAnimationSwiftPlaygrounds) - A set of interesting Core Animation playgounds. ☘️
 * [UIViewPropertyAnimator Playground](https://github.com/mathewsanders/Scrubber) - Playground demonstrating UIViewPropertyAnimator. ☘️
 * [WWDC Crowd Simulator 2017](https://github.com/neilsardesai/WWDC-Crowd-Simulator-2017) - A SpriteKit experiment to simulate the WWDC2017 logo crowd. ☘️
-* [iOS Animation Samples](https://github.com/JakeLin/iOSAnimationSample) - Experiment with iOS animations.
 * [Additive Animations](https://github.com/d-ronnqvist/Additive-Animations-Playground) - Experiment with multiple additive animations in Core Animation.
 * [Core Animation Playground](https://github.com/knightsc/CoreAnimationPlayground) - Companion to Apple's Core Animation Programming Guide.
 * [Duet-Inspired Trail Effect](https://github.com/dionlarson/Duet-Trail-Effect-SpriteKit-Playground) - How to get a Duet style trailing effect in SpriteKit.


### PR DESCRIPTION
JakeLin/iOSAnimationSample doesn't have any playgrounds. It is just an iOS project. I believe the author was using the term "playground" to mean something similar to "sample project".