### PR TITLE
Add the Core Animation Timing playground.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -424,3 +424,6 @@
 [submodule "playgrounds/filip-zielinski/CodablePlayground"]
 	path = playgrounds/filip-zielinski/CodablePlayground
 	url = https://github.com/filip-zielinski/CodablePlayground
+[submodule "playgrounds/kentzo/CoreAnimationTiming"]
+	path = playgrounds/kentzo/CoreAnimationTiming
+	url = https://github.com/Kentzo/CoreAnimationTiming.git

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Awesome Swift Playgrounds [![Awesome](https://awesome.re/badge-flat.svg)](https://awesome.re)  ![150 playgrounds](https://img.shields.io/badge/Playgrounds:-150-orange.svg)
+# Awesome Swift Playgrounds [![Awesome](https://awesome.re/badge-flat.svg)](https://awesome.re)  ![151 playgrounds](https://img.shields.io/badge/Playgrounds:-151-orange.svg)
 
 > A curated list of awesome Swift playgrounds.
 
@@ -235,6 +235,7 @@ Apple's playgrounds distributed as zip archives have to be downloaded manually.
 * [Duet-Inspired Trail Effect](https://github.com/dionlarson/Duet-Trail-Effect-SpriteKit-Playground) - How to get a Duet style trailing effect in SpriteKit.
 * [Additive Animations](https://github.com/d-ronnqvist/Additive-Animations-Playground) - Experiment with multiple additive animations in Core Animation. ⏳
 * [Core Animation Playground](https://github.com/knightsc/CoreAnimationPlayground) - Companion to Apple's Core Animation Programming Guide. ⏳
+* [Core Animation Timing](https://github.com/Kentzo/CoreAnimationTiming) - Playground demonstrating effects of CAMediaTiming properties. 🍁
 
 ### SpriteKit
 


### PR DESCRIPTION
Hi!
Please read CONTRIBUTING.md before completing this PR and verify that you have included the following:
- [x] A working link to the playground you want to add, in the correct category and with a proper description.
- [x] If the playground is meant to be run with Xcode, please create a new directory under playgrounds/ 
    with the username of the author and add the playground as a submodule. 
    For example, if you want to add https://github.com/uraimo/Swift-Playgrounds:
    mkdir playgrounds/uraimo
    cd playgrounds/uraimo
    git submodule add https://github.com/uraimo/Swift-Playgrounds
- [x] Increment the playgrounds counter at the top of README.md, for example: 
    ![133 playgrounds](https://img.shields.io/badge/Playgrounds:-133-orange.svg)
    should become: ![134 playgrounds](https://img.shields.io/badge/Playgrounds:-134-orange.svg)

///////////////////////////////////
